### PR TITLE
Fixed typo

### DIFF
--- a/lemp
+++ b/lemp
@@ -16,7 +16,7 @@ case "$1" in
         sleep 1
     ;;
     stop)
-        echo "Stoppting Nginx..."
+        echo "Stopping Nginx..."
         sudo service nginx stop
         sleep 1
         echo "Stopping PHP7..."


### PR DESCRIPTION
By the way, thank you! It works great but it destroy apache2 previous install:

```
Starting Apache httpd, serving https://prestashop-box-mickaelandrieu.c9users.io/.
/mnt/shared/bin/run-apache2: line 4: /etc/apache2/envvars: No such file or directory
Error: envvars failed
```
